### PR TITLE
Continuation fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,9 @@
 		}
 	],
 	"license": "GPL-2.0+",
+	"minimum-stability": "dev",
 	"require": {
-		"addwiki/mediawiki-api": "0.3"
+		"addwiki/mediawiki-api": "dev-master"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/WikiLovesDownloads.php
+++ b/src/WikiLovesDownloads.php
@@ -63,7 +63,7 @@ class WikiLovesDownloads {
 		);
 
 		# @TODO: extend mediawiki api to accept parameter cmtype 
-		$this->images = $this->filterByNamespace( 'File' );
+		$this->images = $this->filterByNamespace( 6 );
 		
 		$images = array_keys( $this->images->toArray() );
 		while ( true ) {
@@ -141,13 +141,13 @@ class WikiLovesDownloads {
 	}
 
 	/**
-	 * @param string $namespaceTitle
+	 * @param int $namespaceId
 	 * @return Pages
 	 */
-	private function filterByNamespace( $namespaceTitle ) {
+	private function filterByNamespace( $namespaceId ) {
 		$filteredPages = new Pages();
 		foreach ( $this->images->toArray() as $imagePage ) {
-			if( strpos( $imagePage->getTitle(), $namespaceTitle ) === 0 ) {
+			if( $imagePage->getPageIdentifier()->getTitle()->getNs() === $namespaceId ) {
 				$filteredPages->addPage( $imagePage );
 			}
 		}

--- a/src/WikiLovesDownloads.php
+++ b/src/WikiLovesDownloads.php
@@ -106,10 +106,10 @@ class WikiLovesDownloads {
 
 	/**
 	 * Looks up the uploader of the file and returns true if the author should be filtered
-	 * @param array $image
+	 * @param Page $image
 	 * @return bool
 	 */
-	private function isImageOfFilteredUser( $image ) {
+	private function isImageOfFilteredUser( Page $image ) {
 		if ( in_array( $image->imageInfo['user'], $this->userFilter ) ) {
 			$this->numImagesByFilteredUsers++;
 			return true;
@@ -126,14 +126,14 @@ class WikiLovesDownloads {
 
 	private function extendWithImageInfo( $chunk ) {
 		# @todo extend wikimedia api to support files
-		$imageInfo = $this->api->getAction(
+		$imageInfo = $this->api->getRequest( new SimpleRequest(
 			'query',
 			array(
 				'prop' => 'imageinfo',
 				'iiprop' => 'url|user|timestamp',
 				'pageids' => implode( '|', $chunk ),
 			)
-		);
+		) );
 
 		# add image info to the page objects and re-add those to the collection
 		foreach( $imageInfo['query']['pages'] as $pageId => $page ) {

--- a/src/WikiLovesDownloads.php
+++ b/src/WikiLovesDownloads.php
@@ -2,6 +2,7 @@
 use Mediawiki\Api\ApiUser;
 use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\MediawikiFactory;
+use Mediawiki\Api\Options\ListCategoryMembersOptions;
 use Mediawiki\DataModel\Pages;
 
 class WikiLovesDownloads {
@@ -32,11 +33,13 @@ class WikiLovesDownloads {
 
 	/**
 	 * @param array $userFilter
+	 * @param ListCategoryMembersOptions $options
 	 */
-	public function __construct( array $userFilter = null ) {
+	public function __construct( array $userFilter = null, ListCategoryMembersOptions $options = null ) {
 		$this->api = new MediawikiApi( API_URL );
 		$this->services = new MediawikiFactory( $this->api );
 
+		$this->options = $options ?: new ListCategoryMembersOptions();
 		$this->userFilter = $userFilter;
 	}
 
@@ -54,8 +57,11 @@ class WikiLovesDownloads {
 	 * @return bool
 	 */
 	public function loadCategoryMembers( $topCategory ) {
-		$this->images = $this->services->newPageListGetter()->getPageListFromCategoryName( $topCategory );
-		
+		$this->images = $this->services->newPageListGetter()->getPageListFromCategoryName(
+			$topCategory,
+			$this->options
+		);
+
 		# @TODO: extend mediawiki api to accept parameter cmtype 
 		$this->images = $this->filterByNamespace( 'File' );
 		

--- a/src/WikiLovesDownloads.php
+++ b/src/WikiLovesDownloads.php
@@ -34,9 +34,7 @@ class WikiLovesDownloads {
 	 * @param array $userFilter
 	 */
 	public function __construct( array $userFilter = null ) {
-		echo "WikiLovesDownloads v0.1\n";
 		$this->api = new MediawikiApi( API_URL );
-		echo "API client instanciated using " . API_URL . "\n";
 		$this->services = new MediawikiFactory( $this->api );
 
 		$this->userFilter = $userFilter;
@@ -48,13 +46,7 @@ class WikiLovesDownloads {
 	 * @param $password
 	 */
 	public function doApiLogin( $username, $password ) {
-		echo "Logging in " . $username . "\n";
 		$this->loggedIn = $this->api->login( new ApiUser( $username, $password ) );
-		if ( $this->loggedIn ) {
-			echo "Successfully logged in.\n";
-		} else {
-			echo "Login failed, continuing anonymously.\n";
-		}
 	}
 
 	/**
@@ -62,13 +54,10 @@ class WikiLovesDownloads {
 	 * @return bool
 	 */
 	public function loadCategoryMembers( $topCategory ) {
-		echo "Fetching category members of " . $topCategory . "\n";
 		$this->images = $this->services->newPageListGetter()->getPageListFromCategoryName( $topCategory );
-		echo "Found " . count( $this->images->toArray() ) . " pages in specified category.\n";
 		
 		# @TODO: extend mediawiki api to accept parameter cmtype 
 		$this->images = $this->filterByNamespace( 'File' );
-		echo count( $this->images->toArray() ) . " pages left after filtering by namespace 6.\n";
 		
 		$images = array_keys( $this->images->toArray() );
 		while ( true ) {
@@ -143,7 +132,6 @@ class WikiLovesDownloads {
 			$this->images->addPage( $pageObject );
 		}
 		$this->numImageInfoRetrieved += count( $chunk );
-		echo "Retrieving image info. " . ( count( $this->images->toArray() ) - $this->numImageInfoRetrieved ) . " remaining.\n";
 	}
 
 	/**

--- a/src/WikiLovesDownloads.php
+++ b/src/WikiLovesDownloads.php
@@ -10,16 +10,16 @@ use Mediawiki\DataModel\Pages;
 class WikiLovesDownloads {
 
 	const NAMESPACE_FILE = 6;
-	
+
 	/** @var MediawikiApi instance of the api client */
 	private $api = '';
 
 	/** @var Pages collection of images as returned by wikipedia::categorymembers() */
 	private $images = array();
-	
+
 	/** @var array array of lists of files */
 	private $urls = array();
-	
+
 	/** @var true on successful login */
 	private $loggedIn = false;
 
@@ -28,10 +28,10 @@ class WikiLovesDownloads {
 
 	/** @var int number of images created by any filtered user */
 	private $numImagesByFilteredUsers = 0;
-	
+
 	/** @var MediawikiFactory */
 	private $services;
-	
+
 	/** @var int number of images for which the image info had been retrieved */
 	private $numImageInfoRetrieved = 0;
 
@@ -68,7 +68,7 @@ class WikiLovesDownloads {
 
 		# @TODO: extend mediawiki api to accept parameter cmtype 
 		$this->images = $this->filterByNamespace( self::NAMESPACE_FILE );
-		
+
 		$images = array_keys( $this->images->toArray() );
 		while ( true ) {
 			$chunk = array_splice( $images, 0, 50 );
@@ -78,7 +78,7 @@ class WikiLovesDownloads {
 			$this->extendWithImageInfo( $chunk );
 		}
 	}
-	
+
 	/**
 	 * iterate through the collection of pages and distribute the urls to a given number of lists
 	 */
@@ -89,7 +89,7 @@ class WikiLovesDownloads {
 			}
 		}
 	}
-	
+
 	public function getUrls( $numberOfLists = 1 ) {
 		$downloadLists = array_fill( 0, $numberOfLists, array() );
 		$currentListIndex = 0;
@@ -116,7 +116,7 @@ class WikiLovesDownloads {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * @return int
 	 */
@@ -134,7 +134,7 @@ class WikiLovesDownloads {
 				'pageids' => implode( '|', $chunk ),
 			)
 		);
-		
+
 		# add image info to the page objects and re-add those to the collection
 		foreach( $imageInfo['query']['pages'] as $pageId => $page ) {
 			$pageObject = $this->images->get( $pageId );

--- a/src/WikiLovesDownloads.php
+++ b/src/WikiLovesDownloads.php
@@ -3,9 +3,13 @@ use Mediawiki\Api\ApiUser;
 use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\MediawikiFactory;
 use Mediawiki\Api\Options\ListCategoryMembersOptions;
+use Mediawiki\Api\SimpleRequest;
+use Mediawiki\DataModel\Page;
 use Mediawiki\DataModel\Pages;
 
 class WikiLovesDownloads {
+
+	const NAMESPACE_FILE = 6;
 	
 	/** @var MediawikiApi instance of the api client */
 	private $api = '';
@@ -63,7 +67,7 @@ class WikiLovesDownloads {
 		);
 
 		# @TODO: extend mediawiki api to accept parameter cmtype 
-		$this->images = $this->filterByNamespace( 6 );
+		$this->images = $this->filterByNamespace( self::NAMESPACE_FILE );
 		
 		$images = array_keys( $this->images->toArray() );
 		while ( true ) {

--- a/src/initial.php
+++ b/src/initial.php
@@ -1,4 +1,6 @@
 <?php
+use Mediawiki\Api\Options\ListCategoryMembersOptions;
+
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
@@ -18,7 +20,10 @@ $listQuantity = $_POST[ 'listQuantity' ];
 $userFilter = explode( ',' , $_POST[ 'names' ] );
 $downloadCategory = "category:" . $category;
 
-$wld = new WikiLovesDownloads( $userFilter );
+# library's default is 5000, which only works for registered bots
+$options = new ListCategoryMembersOptions();
+$options->setLimit( 500 );
+$wld = new WikiLovesDownloads( $userFilter, $options );
 $create = new ArchiveCreator();
 
 if ( defined( 'API_USER' ) && defined( 'API_PASSWORD' ) ) {


### PR DESCRIPTION
Due to an [API breaking change](https://lists.wikimedia.org/pipermail/wikitech-l/2015-April/081559.html) the continuation functionality stopped working in the API client library. This was fixed by addwiki/mediawiki-api/pull/25, but WLD also needs to be changed to work with the library's current version.
